### PR TITLE
refactor: extract ProductCard component

### DIFF
--- a/src/components/ProductCard.js
+++ b/src/components/ProductCard.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Displays information for a single product in card form.
+ * Accepts a `product` object and optional `showQuickView` and `layout` props.
+ */
+const ProductCard = ({ product, showQuickView = false, layout = 'grid' }) => {
+  if (!product) return null;
+
+  const imageSrc = product.image || (product.images && product.images[0]);
+
+  return (
+    <div className={`product-card ${layout}`}>
+      <div className="product-image position-relative">
+        <Link to={`/product/${product.slug}`} className="d-block">
+          <img
+            src={imageSrc}
+            alt={product.name}
+            className="img-fluid rounded"
+          />
+        </Link>
+
+        {/* Product badges */}
+        <div className="position-absolute top-0 start-0 p-2">
+          {product.featured && (
+            <span className="badge bg-warning text-dark me-1">Öne Çıkan</span>
+          )}
+          {product.bestseller && (
+            <span className="badge bg-success me-1">Çok Satan</span>
+          )}
+          {product.new && (
+            <span className="badge bg-primary">Yeni</span>
+          )}
+        </div>
+
+        {/* Quick view button */}
+        {showQuickView && (
+          <Link
+            to={`/product/${product.slug}`}
+            className="btn btn-sm btn-primary position-absolute top-50 start-50 translate-middle"
+          >
+            İncele
+          </Link>
+        )}
+      </div>
+
+      <div className="product-info text-center mt-3">
+        <h5 className="product-title mb-1">
+          <Link to={`/product/${product.slug}`} className="text-decoration-none text-dark">
+            {product.name}
+          </Link>
+        </h5>
+        {product.category && (
+          <p className="text-muted small mb-2">{product.category}</p>
+        )}
+        <div className="product-price">
+          {product.oldPrice && (
+            <span className="text-muted text-decoration-line-through me-2">
+              {product.oldPrice}₺
+            </span>
+          )}
+          {product.price !== undefined && (
+            <span className="fw-bold">{product.price}₺</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ProductCard;
+

--- a/src/components/ProductCards.js
+++ b/src/components/ProductCards.js
@@ -1,7 +1,7 @@
 // src/components/ProductCards.js
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import ProductCards from './ProductCards';
+import ProductCard from './ProductCard';
 import { products, categories, getFeaturedProducts, getBestsellerProducts } from '../data/products';
 
 const ProductCards = ({ 

--- a/src/pages/ProductDetail.js
+++ b/src/pages/ProductDetail.js
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getProductBySlug, getProductsByCategory } from '../data/products';
-import ProductCard from '../components/ProductCards';
+import ProductCard from '../components/ProductCard';
 
 const ProductDetail = () => {
   const { slug } = useParams();

--- a/src/pages/Products.js
+++ b/src/pages/Products.js
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { useParams, useSearchParams, Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet-async';
-import  ProductCard from '../components/ProductCards'
+import  ProductCard from '../components/ProductCard';
 import { products, categories, getProductsByCategory, searchProducts, getCategoryBySlug } from '../data/products';
 
 const Products = () => {


### PR DESCRIPTION
## Summary
- add reusable ProductCard component for single product display
- update ProductCards to import new component
- fix ProductDetail and Products pages to reference ProductCard

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a8536201f883328215df28145e4bf7